### PR TITLE
feat(s1-11): uni tests para endpoints básicos del backend

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from src.backend.main import app
+
+import pytest
+
+# Este fixture permite crear un cliente reutilizable para los tests. Nos permite probar endpoints de forma controlada.
+@pytest.fixture
+def client():
+    # Con TestClient(app) podemos realizar peticiones a nuestra API sin necesidad de levantar un 
+    # servidor real, es decir, no se va a arrancar uvicorn.
+    return TestClient(app)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,16 +1,156 @@
-import pytest
-from fastapi.testclient import TestClient
+"""
+Test 
+Sprint 1: Validación básica del API
+Se emplea pytest para realizar pruebas unitarias.
+"""
 
 
-@pytest.fixture
-def client():
-    """Fixture para proporcionar un cliente de prueba."""
-    from src.backend.main import app
-    return TestClient(app)
+# ============================================
+# Tests para verificar el endpoint raíz de la API
+# ============================================
 
+# Test para verificar que el endpoint root devuelve la información general de la API
+def test_root_endpoint_returns_api_info(client):
+    # Simulamos una petición HTTP GET a la ruta raíz utilizando el cliente de pruebas
+    response = client.get("/")
 
-def test_health_check(client):
-    """Test del endpoint de health check."""
-    response = client.get("/api/v1/health")
+    # Verificamos que el código de estado HTTP sea 200 OK
     assert response.status_code == 200
-    assert response.json()["status"] == "healthy"
+
+    # Convertimos la respuesta en formato JSON para verificar su contenido
+    data = response.json()
+    assert "message" in data
+    assert "docs" in data
+    assert "version" in data
+
+# Test para verificar que el endpoint root devuelve los valores correctos
+def test_root_endpoint_returns_expected_docs_and_version(client):
+    # Simulamos la petición
+    response = client.get("/")
+    # Convertimos la respuesta en formato JSON para verificar su contenido
+    data = response.json()
+
+    assert data["docs"] == "/docs", f"Se esperaba docs='/docs' y se obtuvo {data['docs']}"
+    assert data["version"] == "1.0.0", f"Se esperaba version='1.0.0' y se obtuvo {data['version']}"
+
+# Test para verificar que el endpoint root devuelve un JSON válido
+def test_root_endpoint_returns_json(client):
+    # Simulamos la petición
+    response = client.get("/")
+    # Verificamos que el tipo de contenido de la respuesta sea JSON, no usamos igualdad estricta porque 
+    # puede incluir charset u otros parámetros
+    assert "application/json" in response.headers["content-type"]
+
+
+# ============================================
+# Tests para verificar los endpoints de documentación
+# ============================================
+
+# Test para verificar que el endpoint de documentación Swagger UI está disponible
+def test_swagger_ui_available(client):
+    # Simulamos una petición HTTP GET a la ruta de documentación Swagger UI
+    response = client.get("/docs")
+    # Verificamos que el código de estado HTTP sea 200 OK, lo que indica que la documentación está disponible
+    assert response.status_code == 200
+
+# Test para verificar que el endpoint de documentación ReDoc está disponible
+def test_redoc_available(client):
+    # Simulamos una petición HTTP GET a la ruta de documentación ReDoc
+    response = client.get("/redoc")
+    # Verificamos que el código de estado HTTP sea 200 OK, lo que indica que la documentación está disponible
+    assert response.status_code == 200
+
+
+# ============================================
+# Tests para verificar el endpoint de documentación OpenAPI JSON
+# ============================================
+
+# Test para verificar que el endpoint de documentación OpenAPI JSON está disponible
+def test_openapi_schema_available(client):
+    # Simulamos una petición HTTP GET a la ruta del esquema OpenAPI JSON
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    # Verificamos que el tipo de contenido de la respuesta sea JSON, no usamos igualdad estricta porque
+    assert "application/json" in response.headers["content-type"]
+
+    data = response.json()
+    assert "info" in data
+    assert "paths" in data
+
+# Test para verificar que el esquema OpenAPI JSON contiene la información personalizada definida en la API
+def test_openapi_schema_contains_custom_metadata(client):
+    # Simulamos una petición HTTP GET a la ruta del esquema OpenAPI JSON
+    response = client.get("/openapi.json")
+    # Convertimos la respuesta en formato JSON para verificar su contenido
+    data = response.json()
+
+    assert data["info"]["title"] == "NEWSRADAR API"
+    assert data["info"]["version"] == "1.0.0"
+    assert data["info"]["description"] == "API REST para procesamiento de canales RSS"
+
+"""
+Para futuros tests mas complejos tener en cuenta la caché app.openapi_schema (la primera llamada genera el esquema
+la segunda reutiliza app.openapi_schema)
+"""
+
+# ============================================
+# Tests de placeholders para endpoints de articles, sources y topics
+# ============================================
+
+# Test para verificar que el endpoint de articles devuelve una estructura vacía inicialmente
+def test_articles_endpoint_structure(client):
+    # Simulamos una petición HTTP GET a la ruta de articles
+    response = client.get("/api/v1/articles")
+
+    # Verificamos que el código de estado HTTP sea 200 OK, lo que indica que el endpoint está disponible
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+
+    # Convertimos la respuesta en formato JSON para verificar su contenido
+    data = response.json()
+    assert "articles" in data
+    assert "count" in data
+
+    # Actualmente el endpoint devuelve una estructura vacía, por lo que verificamos que 
+    # articles sea una lista vacía y count sea 0
+    assert data["articles"] == []
+    assert data["count"] == 0
+
+# Test para verificar que el endpoint de sources devuelve una estructura vacía inicialmente
+def test_sources_endpoint_structure(client):
+    # Simulamos una petición HTTP GET a la ruta de sources
+    response = client.get("/api/v1/sources")
+
+    # Verificamos que el código de estado HTTP sea 200 OK, lo que indica que el endpoint está disponible
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+
+    # Convertimos la respuesta en formato JSON para verificar su contenido
+    data = response.json()
+    assert "sources" in data
+    assert "count" in data
+
+    # Actualmente el endpoint devuelve una estructura vacía, por lo que verificamos que 
+    # sources sea una lista vacía y count sea 0
+    assert data["sources"] == []
+    assert data["count"] == 0
+
+# Test para verificar que el endpoint de topics devuelve una estructura vacía inicialmente
+def test_topics_endpoint_structure(client):
+    # Simulamos una petición HTTP GET a la ruta de topics
+    response = client.get("/api/v1/topics")
+
+    # Verificamos que el código de estado HTTP sea 200 OK, lo que indica que el endpoint está disponible
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+
+    # Convertimos la respuesta en formato JSON para verificar su contenido
+    data = response.json()
+    assert "topics" in data
+    assert "count" in data
+
+    # Actualmente el endpoint devuelve una estructura vacía, por lo que verificamos que 
+    # topics sea una lista vacía y count sea 0
+    assert data["topics"] == []
+    assert data["count"] == 0

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,86 +1,50 @@
 """
-Test para verificar el endpoint de salud de la API
-Sprint 1: Validación básica de la API
+Test para verificar el endpoint de health de la API
+Sprint 1: Validación básica del API
+Se emplea pytest para realizar pruebas unitarias.
 """
-import pytest
-import sys
-import os
-from pathlib import Path
-
-# Agregar el directorio src/backend al path  
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'src' / 'backend'))
-
-from fastapi.testclient import TestClient
-from main import app
 
 
-@pytest.fixture
-def client():
-    """Fixture que proporciona un cliente TestClient para FastAPI."""
-    return TestClient(app)
+# Test para verificar que el endpoint de health de la API responde correctamente
+def test_health_endpoint_returns_200(client):
+    # Simulamos una petición HTTP GET a la ruta /health utilizando el cliente de pruebas
+    response = client.get("/health")
+    assert response.status_code == 200
+
+# Test para verificar que el endpoint de health devuelve la estructura de datos esperada
+def test_health_endpoint_response_structure(client):
+    # Simulamos la petición
+    response = client.get("/health")
+    # Convertimos la respuesta en un diccionario para verificar su contenido
+    data = response.json()
+
+    assert "status" in data
+    assert "service" in data
+    assert "version" in data
+
+# Test para verificar que el endpoint de health devuelve los valores correctos
+def test_health_endpoint_response_values(client):
+    # Simulamos la petición
+    response = client.get("/health")
+    # Convertimos la respuesta en un diccionario para verificar su contenido
+    data = response.json()
+
+    assert data["status"] == "healthy", f"Se esperaba status='healthy' y se obtuvo {data['status']}"
+    assert data["service"] == "NEWSRADAR API", f"Se esperaba service='NEWSRADAR API' y se obtuvo {data['service']}"
+    assert data["version"] == "1.0.0", f"Se esperaba version='1.0.0' y se obtuvo {data['version']}"
+
+# Test para verificar que el endpoint de health devuelve un JSON válido
+def test_health_endpoint_returns_json(client):
+    # Simulamos la petición
+    response = client.get("/health")
+    # Verificamos que el tipo de contenido de la respuesta sea JSON, no usamos igualdad estricta porque 
+    # puede incluir charset u otros parámetros
+    assert "application/json" in response.headers["content-type"]
 
 
-class TestHealthEndpoint:
-    """Suite de tests para el endpoint /health"""
-    
-    def test_health_endpoint_returns_200(self, client):
-        """Verificar que el endpoint /health devuelve HTTP 200."""
-        response = client.get("/health")
-        assert response.status_code == 200
-    
-    def test_health_endpoint_response_structure(self, client):
-        """Verificar que la respuesta tiene la estructura esperada."""
-        response = client.get("/health")
-        json_response = response.json()
-        
-        assert "status" in json_response
-        assert "service" in json_response
-        assert "version" in json_response
-    
-    def test_health_endpoint_response_values(self, client):
-        """Verificar que los valores de la respuesta son correctos."""
-        response = client.get("/health")
-        json_response = response.json()
-        
-        assert json_response["status"] == "healthy"
-        assert json_response["service"] == "NEWSRADAR API"
-        assert json_response["version"] == "1.0.0"
-    
-    def test_health_endpoint_content_type(self, client):
-        """Verificar que el Content-Type es JSON."""
-        response = client.get("/health")
-        assert response.headers["content-type"] == "application/json"
-    
-    def test_root_endpoint_exists(self, client):
-        """Verificar que el endpoint raíz existe y responde."""
-        response = client.get("/")
-        assert response.status_code == 200
-        json_response = response.json()
-        assert "message" in json_response
-        assert "version" in json_response
-
-
-class TestAPIDocumentation:
-    """Suite de tests para la documentación de la API"""
-    
-    def test_swagger_ui_available(self, client):
-        """Verificar que Swagger UI está disponible en /docs."""
-        response = client.get("/docs")
-        assert response.status_code == 200
-    
-    def test_redoc_available(self, client):
-        """Verificar que ReDoc está disponible en /redoc."""
-        response = client.get("/redoc")
-        assert response.status_code == 200
-    
-    def test_openapi_schema_available(self, client):
-        """Verificar que el esquema OpenAPI está disponible."""
-        response = client.get("/openapi.json")
-        assert response.status_code == 200
-        json_response = response.json()
-        assert "info" in json_response
-        assert "paths" in json_response
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+"""
+Nota: Estos tests son básicos y se centran en la verificación de la respuesta del endpoint de health.
+Si en el futuro el endpoint /health devuelve más información
+(p. ej. estado de base de datos, servicios externos o timestamp),
+habrá que ampliar este archivo con nuevas comprobaciones.
+"""


### PR DESCRIPTION
Añade tests unitarios para los endpoints base del backend actual.

Incluye:
- tests para /health
- tests para /, /docs, /redoc y /openapi.json
- tests para los placeholders /api/v1/articles, /api/v1/sources y /api/v1/topics
- fixture compartido en conftest.py

Closes #12 