### PR TITLE
feat(s1-12): Añadir SonarCloud (analisis y reporte)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Ejecutar Tests unitarios con cobertura
         env:
           MONGO_URI: mongodb://admin:password@localhost:27017/
+          PYTHONPATH: ./src/backend
         run: python -m pytest tests/unit --cov=src/backend --cov-report=xml --cov-report=term-missing -v
 
       - name: Subir reporte de cobertura

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,6 +44,9 @@ jobs:
   test:
     name: Ejecutar tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     services:
       mongodb:
@@ -63,6 +66,8 @@ jobs:
     steps:
       - name: Checkout codigo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configurar Python
         uses: actions/setup-python@v5
@@ -90,6 +95,7 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
   # ============================================

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,17 +70,27 @@ jobs:
           python-version: '3.11'
 
       - name: Instalar dependencias
-        working-directory: ./src/backend
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-cov httpx requests
+          python -m pip install -r src/backend/requirements.txt
+          python -m pip install pytest pytest-cov httpx requests
 
-      - name: Ejecutar Tests
-        working-directory: ./src/backend
+      - name: Ejecutar Tests unitarios con cobertura
         env:
           MONGO_URI: mongodb://admin:password@localhost:27017/
-        run: python -m pytest tests/ -v || echo "Tests pendientes de implementacion completa"
+        run: python -m pytest tests/unit --cov=src/backend --cov-report=xml --cov-report=term-missing -v
+
+      - name: Subir reporte de cobertura
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
 
   # ============================================
   # Build de contenedores

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=EliiSD_NewsRadar
+sonar.organization=eliisd
+sonar.sources=src/backend
+sonar.tests=tests
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Añade integración de SonarCloud y generación automática de cobertura en el pipeline.

Incluye:
- ejecución de tests unitarios desde tests/unit
- generación de coverage.xml
- subida del reporte de cobertura como artefacto
- integración de SonarCloud en GitHub Actions
- configuración del proyecto en sonar-project.properties

Closes #13 